### PR TITLE
fix: compute experience timeline durations dynamically

### DIFF
--- a/src/apis/rest/Experience.jsx
+++ b/src/apis/rest/Experience.jsx
@@ -4,7 +4,7 @@ import { MdWork } from "react-icons/md";
 import { getList } from "./common/logics.js";
 import { BACKEND_URLS } from "./common/urls.js";
 import { CustomSortEnum } from "../../utils/choices.js";
-import { calculateAge } from "../../utils/utils.js";
+import { calculateAge, formatDateRange } from "../../utils/utils.js";
 
 const getExperienceList = () => getList({
     urls: BACKEND_URLS,
@@ -39,7 +39,7 @@ const defaultData = [
         avatarBorderColor: null
     },
     {
-        date: "Jul 2016 - Jan 2022 (5 years 7 months)",
+        date: formatDateRange("07/01/2016", "01/31/2022"),
         icon: <MdWork />,
         title: "Synergetech Co., Ltd., Nonthaburi, Thailand",
         content: `Role: Automation System Engineer
@@ -52,7 +52,7 @@ const defaultData = [
         avatarBorderColor: null
     },
     {
-        date: "Jan 2022 - Oct 2022 (10 months)",
+        date: formatDateRange("01/01/2022", "10/31/2022"),
         icon: <FaBookOpenReader />,
         title: "Self-Learning Journey: Software Development",
         content: `
@@ -68,7 +68,7 @@ const defaultData = [
         avatarBorderColor: null
     },
     {
-        date: "Nov 2022 -May 2024 (1 year 7 months)",
+        date: formatDateRange("11/01/2022", "05/31/2024"),
         icon: <MdWork />,
         title: "Swift Dynamics Co., Ltd., Bangkok, Thailand",
         content: `Role: Backend Developer
@@ -80,7 +80,7 @@ const defaultData = [
         avatarBorderColor: null
     },
     {
-        date: `May 2024 - Dec 2025 (${calculateAge("05/08/2024")})`,
+        date: formatDateRange("05/08/2024", "12/31/2025"),
         icon: <MdWork />,
         title: "Zero Friction Co., Ltd., Bangkok, Thailand",
         content: `Role: Software Engineer
@@ -92,7 +92,7 @@ const defaultData = [
         avatarBorderColor: null
     },
     {
-        date: `Jan 2026 - Present (${calculateAge("01/14/2026")})`,
+        date: formatDateRange("01/14/2026"),
         icon: <MdWork />,
         title: "Vulcan Coalition Co., Ltd., Bangkok, Thailand",
         content: `Role: Senior Software Engineer

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -22,3 +22,44 @@ export const calculateAge = (birthdate) => {
 
     return `${years} years`;
 };
+
+const MONTH_LABELS = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+// Durations are counted inclusively - Jan 2026 through Aug 2026 reads as
+// 8 months, not 7 - so both the start and end month are counted.
+export const calculateDuration = (startDate, endDate) => {
+    const start = new Date(startDate);
+    const end = endDate ? new Date(endDate) : new Date();
+
+    if (isNaN(start) || isNaN(end)) return "";
+
+    const totalMonths = Math.max(
+        (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth()) + 1,
+        0
+    );
+
+    const years = Math.floor(totalMonths / 12);
+    const months = totalMonths % 12;
+    const parts = [];
+
+    if (years) parts.push(`${years} year${years > 1 ? "s" : ""}`);
+    if (months) parts.push(`${months} month${months > 1 ? "s" : ""}`);
+
+    return parts.join(" ") || "0 months";
+};
+
+// Renders "Jul 2016 - Jan 2022 (5 years 7 months)". An omitted endDate is
+// an ongoing role, so it reads as "Present" and keeps counting from today.
+export const formatDateRange = (startDate, endDate) => {
+    const start = new Date(startDate);
+    const end = endDate ? new Date(endDate) : null;
+
+    if (isNaN(start) || (end && isNaN(end))) return "";
+
+    const label = (date) => `${MONTH_LABELS[date.getMonth()]} ${date.getFullYear()}`;
+
+    return `${label(start)} - ${end ? label(end) : "Present"} (${calculateDuration(startDate, endDate)})`;
+};


### PR DESCRIPTION
calculateAge measured from a start date to today and returned whole years only, so timeline durations were wrong in two ways: a role that already ended kept counting to the present, and any span under a year collapsed to "0 years".

Zero Friction read "2 years" instead of "1 year 8 months", and Vulcan Coalition read "0 years" instead of "8 months".

Add calculateDuration and formatDateRange, and derive the work entries from real start/end dates instead of hand-written strings, so the counts stay correct as time passes. Months are counted inclusively to match the convention the existing labels already used - the new helper reproduces all of them unchanged.